### PR TITLE
Configuration fix

### DIFF
--- a/rjm/config.py
+++ b/rjm/config.py
@@ -8,7 +8,11 @@ logger = logging.getLogger(__name__)
 
 
 # settings
-CONFIG_FILE_LOCATION = os.path.expanduser("~/.rjm/rjm_config.ini")
+CONFIG_FILE_LOCATION = os.path.join(
+    os.path.expanduser("~"),
+    ".rjm",
+    "rjm_config.ini"
+)
 CONFIG_OPTIONS_REQUIRED = [
     {
         "section": "GLOBUS",

--- a/rjm/config.py
+++ b/rjm/config.py
@@ -29,7 +29,7 @@ CONFIG_OPTIONS_REQUIRED = [
         "help": "Enter the endpoint id of the funcX endpoint running on the remote machine",
     },
 ]
-CONFIG_OPTIONS_OPTIONAL = [
+CONFIG_OPTIONS_OPTIONAL = [  # default values must be strings
     {
         "section": "SLURM",
         "name": "slurm_script",
@@ -39,7 +39,7 @@ CONFIG_OPTIONS_OPTIONAL = [
     {
         "section": "SLURM",
         "name": "poll_interval",
-        "default": 10,
+        "default": "10",
         "help": "Interval (in seconds) between checking whether the Slurm job has completed",
     },
     {

--- a/rjm/utils.py
+++ b/rjm/utils.py
@@ -10,7 +10,11 @@ from . import config as config_helper
 
 
 # default file locations
-TOKEN_FILE_LOCATION = os.path.expanduser("~/.rjm/rjm_tokens.json")
+TOKEN_FILE_LOCATION = os.path.join(
+    os.path.expanduser("~"),
+    ".rjm",
+    "rjm_tokens.json"
+)
 
 # Globus client id for this app
 CLIENT_ID = "b7f9ff16-4094-4d2a-8183-6dfd9362096a"


### PR DESCRIPTION
- fix rjm_configure when selecting "use defaults" the first time
- config and token file paths are created in a cross-platform friendly way