### PR TITLE
Catch errors in the submit Slurm job remote function

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# nonmem example files must have LF endings, even on Windows
+examples/nonmem/files/* text eol=lf

--- a/rjm/errors.py
+++ b/rjm/errors.py
@@ -1,0 +1,5 @@
+class RemoteJobRunnerError(Exception):
+    """
+    Errors related to running the job on the remote system.
+
+    """

--- a/rjm/runners/funcx_slurm_runner.py
+++ b/rjm/runners/funcx_slurm_runner.py
@@ -129,7 +129,7 @@ class FuncxSlurmRunner(RunnerBase):
             self._log(logging.ERROR, f'return code: {returncode}')
             self._log(logging.ERROR, f'output: {stdout}')
             started = False
-            raise RemoteJobRunnerError(f"{self._label} failed to submit Slurm job: {stdout}")
+            raise RemoteJobRunnerError(f"{self._label}failed to submit Slurm job: {stdout}")
 
         return started
 

--- a/rjm/runners/funcx_slurm_runner.py
+++ b/rjm/runners/funcx_slurm_runner.py
@@ -158,7 +158,7 @@ class FuncxSlurmRunner(RunnerBase):
                 self._log(logging.ERROR, f'Checking job status failed for {self._jobid}')
                 self._log(logging.ERROR, f'return code: {returncode}')
                 self._log(logging.ERROR, f'output: {job_status}')
-                break
+                raise RemoteJobRunnerError(f"{self._label}failed to get Slurm job status: {job_status}")
 
         if job_finished:
             self._log(logging.INFO, f"Slurm job {self._jobid} has finished")


### PR DESCRIPTION
Exceptions raised during the remote function get wrapped in a parsl class, which can cause problems when they sent back to the host if parsl is not installed, so catch them and return a string and error code instead.

Also, rjm_batch_submit and rjm_batch_wait will exit with nonzero error code if any directories failed.